### PR TITLE
`formatMonth` to allow customize month abbreviation

### DIFF
--- a/demo/App/App.tsx
+++ b/demo/App/App.tsx
@@ -44,6 +44,11 @@ const App: React.FunctionComponent = () => {
                 month: "short",
               }).format(date)
             }
+            formatMonth={(date: Date) =>
+              new Intl.DateTimeFormat("en", {
+                month: "short",
+              }).format(date)
+            }
             // formatDay={(dayOfWeek: number) => {
             //   const date = new Date(0);
             //   date.setDate(4 + dayOfWeek);

--- a/src/components/CalendarHeatMap/CalendarHeatMap.tsx
+++ b/src/components/CalendarHeatMap/CalendarHeatMap.tsx
@@ -35,6 +35,7 @@ const CalendarHeatMap = <
   cellSize = 17,
   cellShape = "circle",
   formatDate = utcFormat("%Y-%m-%d"),
+  formatMonth = utcFormat("%b"),
   valueFn = format(".2f"),
   defaultColor = "#eeeeee",
   marginTop = 0,
@@ -95,9 +96,6 @@ const CalendarHeatMap = <
           value: 0,
         } as CalendarHeatMapItemType);
   });
-
-  // formatting
-  const formatMonth = utcFormat("%b");
 
   // color
   const max = quantile(timeRangeData, 0.9975, (d) => Math.abs(d.value));

--- a/src/components/CalendarHeatMap/CalendarHeatMapProps.ts
+++ b/src/components/CalendarHeatMap/CalendarHeatMapProps.ts
@@ -61,6 +61,8 @@ export interface CalendarHeatMapProps<CalendarHeatMapItemType> {
 
   formatDate?: (date: Date) => string;
 
+  formatMonth?: (date: Date) => string;
+
   formatDay?: (dayOfWeek: number) => string;
 
   /**


### PR DESCRIPTION
related to https://github.com/jquintozamora/react-d3-calendar-heatmap/issues/1